### PR TITLE
Fixing dashboard permission URI callbacks

### DIFF
--- a/dashboards_permissions.go
+++ b/dashboards_permissions.go
@@ -32,7 +32,7 @@ type DashboardPermission struct {
 }
 
 func (s *DashboardsPermissionsService) GetDashboardPermissions(id int) (*DashboardPermissions, *Response, error) {
-	u := fmt.Sprintf("dashboards/%d/permissions", id)
+	u := fmt.Sprintf("dashboards/id/%d/permissions", id)
 
 	req, err := s.client.NewRequest("GET", u, nil, nil)
 	if err != nil {
@@ -52,7 +52,7 @@ type UpdateDashboardPermissionsOptions struct {
 }
 
 func (s *DashboardsPermissionsService) UpdateDashboardPermissions(id int, opt *UpdateDashboardPermissionsOptions) (*Response, error) {
-	u := fmt.Sprintf("dashboards/%d/permissions", id)
+	u := fmt.Sprintf("dashboards/id/%d/permissions", id)
 
 	req, err := s.client.NewRequest("POST", u, opt, nil)
 	if err != nil {


### PR DESCRIPTION
According to the documentation https://grafana.com/docs/grafana/v8.4/http_api/dashboard_permissions/ (and internal tests) need to change uri of dashboard permission callbacks